### PR TITLE
Setup SSE for S3-compatible providers

### DIFF
--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -165,6 +165,8 @@ spec:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
 {{- if eq .Values.backup.storageProvider "S3" }}
+        - name: "AWS_SSE_CUSTOMER_KEY"
+          value: {{ .Values.sseCustomerKey }}
         - name: "AWS_REGION"
           valueFrom:
             secretKeyRef:

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -165,8 +165,10 @@ spec:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
 {{- if eq .Values.backup.storageProvider "S3" }}
+        {{- if .Values.sseCustomerKey }}
         - name: "AWS_SSE_CUSTOMER_KEY"
           value: {{ .Values.sseCustomerKey }}
+        {{- end }}
         - name: "AWS_REGION"
           valueFrom:
             secretKeyRef:

--- a/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
+++ b/chart/etcd-backup-restore/templates/etcd-statefulset.yaml
@@ -165,10 +165,6 @@ spec:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
 {{- if eq .Values.backup.storageProvider "S3" }}
-        {{- if .Values.sseCustomerKey }}
-        - name: "AWS_SSE_CUSTOMER_KEY"
-          value: {{ .Values.sseCustomerKey }}
-        {{- end }}
         - name: "AWS_REGION"
           valueFrom:
             secretKeyRef:

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -153,3 +153,6 @@ backupRestoreTLS: {}
 
 # podAnnotations that will be passed to the resulting etcd pod
 podAnnotations: {}
+
+# sseCustomerKey is the AES Key used to enable Server Side Encryption
+sseCustomerKey: ""

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -88,7 +88,8 @@ backup:
   #   region: region-where-bucket-exists
   #   secretAccessKey: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-route53-privileges
-  #   sseCustomerKey: aes-256-sse-customer-key
+  #   sseCustomerKey: aes-256-sse-customer-key # optional
+  #   sseCustomerAlgorithm: aes-256-sse-customer-algorithm # optional
   # gcs:
   #   serviceAccountJson: service-account-json-with-object-storage-privileges
   #   storageAPIEndpoint: endpoint-override-for-storage-api # optional

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -155,4 +155,4 @@ backupRestoreTLS: {}
 podAnnotations: {}
 
 # sseCustomerKey is the AES Key used to enable Server Side Encryption
-sseCustomerKey: ""
+# sseCustomerKey: <aes-256-key> # Expects a string value

--- a/chart/etcd-backup-restore/values.yaml
+++ b/chart/etcd-backup-restore/values.yaml
@@ -88,6 +88,7 @@ backup:
   #   region: region-where-bucket-exists
   #   secretAccessKey: secret-access-key-with-object-storage-privileges
   #   accessKeyID: access-key-id-with-route53-privileges
+  #   sseCustomerKey: aes-256-sse-customer-key
   # gcs:
   #   serviceAccountJson: service-account-json-with-object-storage-privileges
   #   storageAPIEndpoint: endpoint-override-for-storage-api # optional
@@ -153,6 +154,3 @@ backupRestoreTLS: {}
 
 # podAnnotations that will be passed to the resulting etcd pod
 podAnnotations: {}
-
-# sseCustomerKey is the AES Key used to enable Server Side Encryption
-# sseCustomerKey: <aes-256-key> # Expects a string value

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -16,7 +16,7 @@ The procedure to provide credentials to access the cloud provider object store v
 * For `AWS S3`: 
    1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
    2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
-   3. To enable Server-Side Encryption for `S3-compatible providers`, use `sseCustomerKey` and `sseCustomerAlgorithm` in the credentials file above. The `sseCustomerKey` should an AES-256 key and the `sseCustomerAlgorithm` should be set to `AES256`(Currently the only supported algorithm)
+   3. To enable Server-Side Encryption using Customer Managed Keys for `S3-compatible providers`, use `sseCustomerKey` and `sseCustomerAlgorithm` in the credentials file above. For example, `sseCustomerAlgorithm` could be set to `AES256`, and correspondingly the `sseCustomerKey` is set to a valid AES-256 key.
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.

--- a/docs/deployment/getting_started.md
+++ b/docs/deployment/getting_started.md
@@ -16,6 +16,7 @@ The procedure to provide credentials to access the cloud provider object store v
 * For `AWS S3`: 
    1. The secret file should be provided, and the file path should be made available as environment variables: `AWS_APPLICATION_CREDENTIALS` or `AWS_APPLICATION_CREDENTIALS_JSON`.
    2. For `S3-compatible providers` such as MinIO, `endpoint`, `s3ForcePathStyle`, `insecureSkipVerify` and `trustedCaCert`, can also be made available in a above file to configure the S3 client to communicate to a non-AWS provider.
+   3. To enable Server-Side Encryption for `S3-compatible providers`, use `sseCustomerKey` and `sseCustomerAlgorithm` in the credentials file above. The `sseCustomerKey` should an AES-256 key and the `sseCustomerAlgorithm` should be set to `AES256`(Currently the only supported algorithm)
 
 * For  `Google Cloud Storage`: 
    1. The service account json file should be provided in the `~/.gcp` as a `service-account-file.json` file.

--- a/pkg/snapstore/generic_s3_snapstore.go
+++ b/pkg/snapstore/generic_s3_snapstore.go
@@ -46,6 +46,5 @@ func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUpl
 		return nil, fmt.Errorf("could not create S3 session: %v", err)
 	}
 	cli := s3.New(sess)
-	sseCreds := sseCredentials{}
-	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli, sseCreds), nil
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli, SSECredentials{}), nil
 }

--- a/pkg/snapstore/generic_s3_snapstore.go
+++ b/pkg/snapstore/generic_s3_snapstore.go
@@ -46,5 +46,6 @@ func newGenericS3FromAuthOpt(bucket, prefix, tempDir string, maxParallelChunkUpl
 		return nil, fmt.Errorf("could not create S3 session: %v", err)
 	}
 	cli := s3.New(sess)
-	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli), nil
+	sseCreds := sseCredentials{}
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli, sseCreds), nil
 }

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -190,7 +190,6 @@ func readAWSCredentialFiles(dirname string) (session.Options, SSECredentials, er
 				InsecureSkipVerify: false,
 				MinVersion:         tls.VersionTLS13,
 			},
-			// AWS managed Server Side Encryption
 		}
 	}
 	sseCreds, err := getSSECreds(awsConfig.SSECustomerKey, awsConfig.SSECustomerAlgorithm)

--- a/pkg/snapstore/s3_snapstore.go
+++ b/pkg/snapstore/s3_snapstore.go
@@ -56,6 +56,13 @@ type awsCredentials struct {
 	TrustedCaCert      *string `json:"trustedCaCert,omitempty"`
 }
 
+// sseCredentials to hold fields for server-side encryption in I/O operations
+type sseCredentials struct {
+	SSECustomerAlgorithm string
+	SSECustomerKey       string
+	SSECustomerKeyMD5    string
+}
+
 // S3SnapStore is snapstore with AWS S3 object store as backend
 type S3SnapStore struct {
 	prefix    string
@@ -66,6 +73,7 @@ type S3SnapStore struct {
 	maxParallelChunkUploads uint
 	minChunkSize            int64
 	tempDir                 string
+	sseCreds                sseCredentials
 }
 
 // NewS3SnapStore create new S3SnapStore from shared configuration with specified bucket
@@ -84,7 +92,8 @@ func newS3FromSessionOpt(bucket, prefix, tempDir string, maxParallelChunkUploads
 		return nil, fmt.Errorf("new AWS session failed: %v", err)
 	}
 	cli := s3.New(sess)
-	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli), nil
+	sseCreds := getSSECreds()
+	return NewS3FromClient(bucket, prefix, tempDir, maxParallelChunkUploads, minChunkSize, cli, sseCreds), nil
 }
 
 func getSessionOptions(prefixString string) (session.Options, error) {
@@ -267,7 +276,7 @@ func readAWSCredentialFromDir(dirname string) (*awsCredentials, error) {
 }
 
 // NewS3FromClient will create the new S3 snapstore object from S3 client
-func NewS3FromClient(bucket, prefix, tempDir string, maxParallelChunkUploads uint, minChunkSize int64, cli s3iface.S3API) *S3SnapStore {
+func NewS3FromClient(bucket, prefix, tempDir string, maxParallelChunkUploads uint, minChunkSize int64, cli s3iface.S3API, sseCreds sseCredentials) *S3SnapStore {
 	return &S3SnapStore{
 		bucket:                  bucket,
 		prefix:                  prefix,
@@ -275,18 +284,18 @@ func NewS3FromClient(bucket, prefix, tempDir string, maxParallelChunkUploads uin
 		maxParallelChunkUploads: maxParallelChunkUploads,
 		minChunkSize:            minChunkSize,
 		tempDir:                 tempDir,
+		sseCreds:                sseCreds,
 	}
 }
 
 // Fetch should open reader for the snapshot file from store
 func (s *S3SnapStore) Fetch(snap brtypes.Snapshot) (io.ReadCloser, error) {
-	sseCreds := getSSECreds()
 	resp, err := s.client.GetObject(&s3.GetObjectInput{
 		Bucket:               aws.String(s.bucket),
 		Key:                  aws.String(path.Join(snap.Prefix, snap.SnapDir, snap.SnapName)),
-		SSECustomerAlgorithm: &sseCreds.SSECustomerAlgorithm,
-		SSECustomerKey:       &sseCreds.SSECustomerKey,
-		SSECustomerKeyMD5:    &sseCreds.SSECustomerKeyMD5,
+		SSECustomerAlgorithm: aws.String(s.sseCreds.SSECustomerAlgorithm),
+		SSECustomerKey:       aws.String(s.sseCreds.SSECustomerKey),
+		SSECustomerKeyMD5:    aws.String(s.sseCreds.SSECustomerKeyMD5),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while accessing %s: %v", path.Join(snap.Prefix, snap.SnapDir, snap.SnapName), err)
@@ -320,13 +329,12 @@ func (s *S3SnapStore) Save(snap brtypes.Snapshot, rc io.ReadCloser) error {
 	ctx, cancel := context.WithTimeout(ctx, chunkUploadTimeout)
 	defer cancel()
 	prefix := adaptPrefix(&snap, s.prefix)
-	sseCreds := getSSECreds()
 	uploadOutput, err := s.client.CreateMultipartUploadWithContext(ctx, &s3.CreateMultipartUploadInput{
 		Bucket:               aws.String(s.bucket),
 		Key:                  aws.String(path.Join(prefix, snap.SnapDir, snap.SnapName)),
-		SSECustomerAlgorithm: &sseCreds.SSECustomerAlgorithm,
-		SSECustomerKey:       &sseCreds.SSECustomerKey,
-		SSECustomerKeyMD5:    &sseCreds.SSECustomerKeyMD5,
+		SSECustomerAlgorithm: aws.String(s.sseCreds.SSECustomerAlgorithm),
+		SSECustomerKey:       aws.String(s.sseCreds.SSECustomerKey),
+		SSECustomerKeyMD5:    aws.String(s.sseCreds.SSECustomerKeyMD5),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initiate multipart upload %v", err)
@@ -416,16 +424,15 @@ func (s *S3SnapStore) uploadPart(snap *brtypes.Snapshot, file *os.File, uploadID
 	ctx, cancel := context.WithTimeout(context.TODO(), chunkUploadTimeout)
 	defer cancel()
 	partNumber := ((offset / chunkSize) + 1)
-	sseCreds := getSSECreds()
 	in := &s3.UploadPartInput{
 		Bucket:               aws.String(s.bucket),
 		Key:                  aws.String(path.Join(adaptPrefix(snap, s.prefix), snap.SnapDir, snap.SnapName)),
 		PartNumber:           &partNumber,
 		UploadId:             uploadID,
 		Body:                 sr,
-		SSECustomerAlgorithm: &sseCreds.SSECustomerAlgorithm,
-		SSECustomerKey:       &sseCreds.SSECustomerKey,
-		SSECustomerKeyMD5:    &sseCreds.SSECustomerKeyMD5,
+		SSECustomerAlgorithm: aws.String(s.sseCreds.SSECustomerAlgorithm),
+		SSECustomerKey:       aws.String(s.sseCreds.SSECustomerKey),
+		SSECustomerKeyMD5:    aws.String(s.sseCreds.SSECustomerKeyMD5),
 	}
 
 	part, err := s.client.UploadPartWithContext(ctx, in)
@@ -537,21 +544,13 @@ func isAWSConfigEmpty(config *awsCredentials) error {
 	return fmt.Errorf("aws s3 credentials: region, secretAccessKey or accessKeyID is missing")
 }
 
-// sseCredentials to hold fields for server-side encryption in I/O operations
-type sseCredentials struct {
-	SSECustomerAlgorithm string
-	SSECustomerKey       string
-	SSECustomerKeyMD5    string
-}
-
 // Checks for SSECustomerKey env var and creates the creds necessary
 func getSSECreds() (ssecreds sseCredentials) {
 	if SSECustomerKey, isSet := os.LookupEnv(sseCustomerKey); isSet {
 		SSECustomerKeyMD5Bytes := md5.Sum([]byte(SSECustomerKey))
 		SSECustomerKeyMD5 := base64.StdEncoding.EncodeToString(SSECustomerKeyMD5Bytes[:])
-		SSECustomerAlgorithm := sseCustomerAlgorithm
 		return sseCredentials{
-			SSECustomerAlgorithm: SSECustomerAlgorithm,
+			SSECustomerAlgorithm: sseCustomerAlgorithm,
 			SSECustomerKey:       SSECustomerKey,
 			SSECustomerKeyMD5:    SSECustomerKeyMD5,
 		}

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -557,6 +557,71 @@ var _ = Describe("Blob Service URL construction for Azure", func() {
 	})
 })
 
+var _ = Describe("Server Side Encryption Customer Managed Key for S3", func() {
+	s3SnapstoreConfig := brtypes.SnapstoreConfig{
+		Provider:  "S3",
+		Container: "etcd-test",
+		Prefix:    "v2",
+	}
+	var credentialDirectory, credentialFilePath string
+	BeforeEach(func() {
+		credentialDirectory = GinkgoT().TempDir()
+		credentialFilePath = filepath.Join(credentialDirectory, "credentials.json")
+		GinkgoT().Setenv("AWS_APPLICATION_CREDENTIALS_JSON", credentialFilePath)
+	})
+	Context("when no SSE-C keys are provided", func() {
+		It("should return the snapstore without errors", func() {
+			// SSE-C fields not present
+			err := os.WriteFile(credentialFilePath, []byte(`{
+  "accessKeyID": "XXXXXXXXXXXXXXXXXXXX",
+  "secretAccessKey": "XXXXXXXXXXXXXXXXXXXX",
+  "region": "eu-west-1"
+}`), os.ModePerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = NewS3SnapStore(&s3SnapstoreConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+	Context("when SSE-C is enabled", func() {
+		It("should return an error if both fields for SSE-C are not provided", func() {
+			// both SSE-C fields are not present
+			// sseCustomerKey not present
+			err := os.WriteFile(credentialFilePath, []byte(`{
+  "accessKeyID": "XXXXXXXXXXXXXXXXXXXX",
+  "secretAccessKey": "XXXXXXXXXXXXXXXXXXXX",
+  "region": "eu-west-1",
+  "sseCustomerAlgorithm": "AES256"
+}`), os.ModePerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = NewS3SnapStore(&s3SnapstoreConfig)
+			Expect(err).Should(HaveOccurred())
+			// sseCustomerAlgorithm not present
+			err = os.WriteFile(credentialFilePath, []byte(`{
+  "accessKeyID": "XXXXXXXXXXXXXXXXXXXX",
+  "secretAccessKey": "XXXXXXXXXXXXXXXXXXXX",
+  "region": "eu-west-1",
+  "sseCustomerKey": "2b7e151628aed2a6abf7158809cf4f3c6afe5028f1959c27a11253edc6cf4f3c"
+}`), os.ModePerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = NewS3SnapStore(&s3SnapstoreConfig)
+			Expect(err).Should(HaveOccurred())
+		})
+		It("should return the snapstore without errors if both fields are provided", func() {
+			// both SSE-C fields are present
+			err := os.WriteFile(credentialFilePath, []byte(`{
+  "accessKeyID": "XXXXXXXXXXXXXXXXXXXX",
+  "secretAccessKey": "XXXXXXXXXXXXXXXXXXXX",
+  "region": "eu-west-1",
+  "sseCustomerAlgorithm": "AES256",
+  "sseCustomerKey": "2b7e151628aed2a6abf7158809cf4f3c6afe5028f1959c27a11253edc6cf4f3c"
+}`), os.ModePerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = NewS3SnapStore(&s3SnapstoreConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})
+
 // createCredentialFilesInDirectory creates access credential files in the
 // specified directory and returns the timestamp of the last modified file.
 func createCredentialFilesInDirectory(directory string, filenames []string) (time.Time, error) {

--- a/pkg/snapstore/snapstore_test.go
+++ b/pkg/snapstore/snapstore_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
-			}),
+			}, SSECredentials{}),
 			"swift": NewSwiftSnapstoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, fake.ServiceClient(), false),
 			"ABS":   newFakeABSSnapstore(),
 			"GCS": NewGCSSnapStoreFromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockGCSClient{
@@ -116,12 +116,12 @@ var _ = Describe("Save, List, Fetch, Delete from mock snapstore", func() {
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
-			}),
+			}, SSECredentials{}),
 			"OCS": NewS3FromClient(bucket, prefixV2, "/tmp", 5, brtypes.MinChunkSize, &mockS3Client{
 				objects:          objectMap,
 				prefix:           prefixV2,
 				multiPartUploads: map[string]*[][]byte{},
-			}),
+			}, SSECredentials{}),
 		}
 	})
 	AfterEach(func() {


### PR DESCRIPTION
Implement SSE.
For testing:
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-creds-file
  namespace: kube-system
data:
  credentials-file: |-
    {
      "accessKeyID": "3US5BDPACM39LIQOGH3Z",
      "secretAccessKey": "wUaH5tjVh3snCqZFAwMRPpP7FdUOh7qvUdg2PGIQ",
      "region": "us-ord-1",
      "endpoint": "us-ord-1.linodeobjects.com"
    }
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: etcd-backup
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: etcd
  updateStrategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: etcd
    spec:
      containers:
      - name: backup-restore
        command:
        - /etcdbrctl
        - snapshot
        - --schedule=*/10 * * * *
        - --garbage-collection-period=1m
        - --storage-provider=S3
        - --store-prefix=etcd-backup
        - --insecure-transport=true
        - --insecure-skip-tls-verify=true
        - --endpoints=https://127.0.0.1:2379
        - --defragmentation-schedule=0 0 */3 * *
        - --etcd-connection-timeout=30s
        - --delta-snapshot-period=60s
        - --delta-snapshot-memory-limit=104857600
        - --compress-snapshots=true        
        - --compression-policy=gzip
        - --cacert=/etc/kubernetes/pki/etcd/ca.crt
        - --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt
        - --key=/etc/kubernetes/pki/etcd/healthcheck-client.key
        image: docker.io/amoldeodhar/aws-sse:0.1.using-env
        securityContext:
          allowPrivilegeEscalation: false
          runAsUser: 0
        imagePullPolicy: Always
        ports:
        - containerPort: 8080
          name: server
          protocol: TCP
        resources:
          limits:
            cpu: 100m
            memory: 1Gi
          requests:
            cpu: 23m
            memory: 128Mi
        env:
        - name: AWS_APPLICATION_CREDENTIALS_JSON
          value: "/home/.aws/credentials-file"
        - name: "STORAGE_CONTAINER"
          value: "capl-testing"
        - name: "SSECustomerKey"
          value: "cdQdZ3PrKgm5vmqxeqwQCuAWJ7pPVyHg"
        volumeMounts:
        - name: aws-config-file
          mountPath: /home/.aws
        - mountPath: /etc/kubernetes/pki
          name: k8s-certs
          readOnly: true
      hostNetwork: true
      volumes:
      - name: aws-config-file
        configMap:
          name: aws-creds-file
          defaultMode: 0644
          items:
          - key: "credentials-file"
            path: "credentials-file"
      - hostPath:
          path: /etc/kubernetes/pki
          type: DirectoryOrCreate
        name: k8s-certs
```
And check if the snapshot can be downloaded via the UI (Should get an error)
And then exclude the env var from the container definition and try the same and this time being unencrypted the download should be successful